### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -4,16 +4,19 @@ on: [push, pull_request, release]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11, 17-ea ]
     permissions:
       contents: read
       packages: write
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK11
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        distribution: 'zulu'
         server-id: github
         settings-path: ${{ github.workspace }}
     - name: Validate Gradle wrapper

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17-ea ]
+        java: [ 11 ]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. Added a matrix for Java versions having JDK 11, in the near future jdk 17 will be an LTS release.